### PR TITLE
Fix import organization to resolve isort linting issues

### DIFF
--- a/bfjira/main.py
+++ b/bfjira/main.py
@@ -5,6 +5,12 @@ import os
 import sys
 from importlib import metadata
 
+from git import Repo
+
+from bfjira.git_utils import create_branch, pop_stash, stash_changes, to_git_root
+from bfjira.jira_utils import branch_name, get_client, transition_to_in_progress
+from bfjira.log_config import setup_logging
+
 try:
     CLI_VERSION = metadata.version("bfjira")
 except metadata.PackageNotFoundError:
@@ -40,11 +46,6 @@ def main():
     parser.add_argument("--version", action="version", version=CLI_VERSION)
 
     args = parser.parse_args()
-
-    from git import Repo
-    from bfjira.git_utils import create_branch, pop_stash, stash_changes, to_git_root
-    from bfjira.jira_utils import branch_name, get_client, transition_to_in_progress
-    from bfjira.log_config import setup_logging
 
     logger = setup_logging(verbose=args.verbose)
 


### PR DESCRIPTION
## Summary

This PR fixes the failing `isort` linting checks in the GitHub Actions CI workflow by properly organizing imports in `bfjira/main.py`.

## Changes Made

- **Moved all imports to the top of the file**: Previously, some imports were placed inside functions, which violates Python best practices and isort rules
- **Organized imports according to isort standards**: Grouped and sorted imports properly (standard library, third-party, local)
- **Fixed relative import placement**: Moved relative imports from `bfjira.*` to the top level
- **Maintained functionality**: All existing functionality remains intact

## What Was Fixed

The main issue was in `bfjira/main.py` where:
- `from git import Repo` was imported inside the `main()` function
- Relative imports like `from bfjira.git_utils import ...` were also inside functions
- This caused isort to fail with import organization errors

## Verification

All linting checks now pass:
- ✅ `black` - code formatting
- ✅ `isort` - import sorting  
- ✅ `mypy` - type checking
- ✅ `ruff` - additional linting

## Impact

- Resolves failing CI workflow runs
- Improves code quality and maintainability
- Follows Python best practices for import organization
- No functional changes to the application

Closes: [Add issue number if applicable]